### PR TITLE
Add MOCK_CUSTOM platform

### DIFF
--- a/selfdrive/car/fingerprints.py
+++ b/selfdrive/car/fingerprints.py
@@ -343,4 +343,5 @@ MIGRATION = {
   "SKODA SUPERB 3RD GEN": VW.SKODA_SUPERB_MK3,
 
   "mock": MOCK.MOCK,
+  "mock_custom": MOCK.MOCK_CUSTOM,
 }

--- a/selfdrive/car/mock/fingerprints.py
+++ b/selfdrive/car/mock/fingerprints.py
@@ -1,0 +1,12 @@
+from cereal import car
+from openpilot.selfdrive.car.mock.values import CAR
+
+Ecu = car.CarParams.Ecu
+
+FW_VERSIONS = {
+  CAR.MOCK_CUSTOM: {
+    (Ecu.eps, 0x730, None): [
+      b'TeM3_SP_XP002p2_0.0.0 (23),SPP003.6.0',
+    ],
+  },
+}

--- a/selfdrive/car/mock/values.py
+++ b/selfdrive/car/mock/values.py
@@ -7,3 +7,9 @@ class CAR(Platforms):
     CarSpecs(mass=1700, wheelbase=2.7, steerRatio=13),
     {}
   )
+
+  MOCK_CUSTOM = PlatformConfig(
+    [],
+    CarSpecs(mass=1500, wheelbase=2.6, steerRatio=12),
+    {}
+  )


### PR DESCRIPTION
## Summary
- support a custom MOCK car platform
- include EPS firmware for the custom platform
- keep migration map in sync

## Testing
- `pre-commit run --files selfdrive/car/mock/values.py selfdrive/car/mock/fingerprints.py selfdrive/car/values.py selfdrive/car/fingerprints.py` *(fails: mypy errors)*
- `pytest selfdrive/car/tests` *(fails: ModuleNotFoundError: openpilot.common.params_pyx)*

------
https://chatgpt.com/codex/tasks/task_e_684c84c2a2a0832897bc48d613b08aa6