### PR TITLE
Add mock FW_QUERY_CONFIG

### DIFF
--- a/selfdrive/car/mock/values.py
+++ b/selfdrive/car/mock/values.py
@@ -1,4 +1,8 @@
+from cereal import car
 from openpilot.selfdrive.car import CarSpecs, PlatformConfig, Platforms
+from openpilot.selfdrive.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
+
+Ecu = car.CarParams.Ecu
 
 
 class CAR(Platforms):
@@ -7,3 +11,15 @@ class CAR(Platforms):
     CarSpecs(mass=1700, wheelbase=2.7, steerRatio=13),
     {}
   )
+
+
+FW_QUERY_CONFIG = FwQueryConfig(
+  requests=[
+    Request(
+      [StdQueries.TESTER_PRESENT_REQUEST, StdQueries.UDS_VERSION_REQUEST],
+      [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.UDS_VERSION_RESPONSE],
+      whitelist_ecus=[Ecu.eps],
+      bus=0,
+    ),
+  ],
+)


### PR DESCRIPTION
## Summary
- configure firmware queries for mock car so it's discoverable by `get_interface_attr`

## Testing
- `SKIP=mypy pre-commit run --files selfdrive/car/mock/values.py`
- `pytest -k mock selfdrive/car/tests/test_car_interfaces.py -vv` *(fails: ModuleNotFoundError: No module named 'openpilot.common.params_pyx')*

------
https://chatgpt.com/codex/tasks/task_e_684c9460023c83289efc5e5d5f0c7c64