### PR TITLE
Add DriverCameraHardwareMissing parameter

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -207,6 +207,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"UpdaterTargetBranch", CLEAR_ON_MANAGER_START},
     {"UpdaterLastFetchTime", PERSISTENT},
     {"Version", PERSISTENT},
+    {"DriverCameraHardwareMissing", PERSISTENT},
 
     // FrogPilot parameters
     {"AccelerationPath", PERSISTENT | FROGPILOT_STORAGE | FROGPILOT_VISUALS},

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -87,6 +87,10 @@ class Controls:
 
     self.sensor_packets = ["accelerometer", "gyroscope"]
     self.camera_packets = ["roadCameraState", "driverCameraState", "wideRoadCameraState"]
+    self.d_camera_hardware_missing = self.params.get_bool("DriverCameraHardwareMissing")
+    if self.d_camera_hardware_missing:
+      IGNORE_PROCESSES.update({"dmonitoringd", "dmonitoringmodeld"})
+      self.camera_packets.remove("driverCameraState")
 
     self.log_sock = messaging.sub_sock('androidLog')
 
@@ -96,6 +100,8 @@ class Controls:
     ignore = self.sensor_packets + ['testJoystick']
     if SIMULATION:
       ignore += ['driverCameraState', 'managerState']
+    if self.d_camera_hardware_missing:
+      ignore += ['driverMonitoringState']
     if REPLAY:
       # no vipc in replay will make them ignored anyways
       ignore += ['roadCameraState', 'wideRoadCameraState']
@@ -239,7 +245,7 @@ class Controls:
     if not self.CP.pcmCruise and not self.v_cruise_helper.v_cruise_initialized and self.resume_pressed:
       self.events.add(EventName.resumeBlocked)
 
-    if not self.CP.notCar:
+    if not self.CP.notCar and not self.d_camera_hardware_missing:
       self.events.add_from_msg(self.sm['driverMonitoringState'].events)
 
     # Add car events, ignore if CAN isn't valid
@@ -337,6 +343,9 @@ class Controls:
       if not SIMULATION and not self.rk.lagging:
         if not self.sm.all_alive(self.camera_packets):
           self.events.add(EventName.cameraMalfunction)
+          if not self.sm.all_alive(['driverCameraState']) and not self.d_camera_hardware_missing:
+            self.d_camera_hardware_missing = True
+            self.params.put_bool_nonblocking("DriverCameraHardwareMissing", True)
         elif not self.sm.all_freq_ok(self.camera_packets):
           self.events.add(EventName.cameraFrameRate)
     if not REPLAY and self.rk.lagging:

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -60,6 +60,12 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
       "../assets/offroad/icon_monitoring.png",
     },
     {
+      "DriverCameraHardwareMissing",
+      tr("DriverCamera Hardware Missing"),
+      tr("DriverCamera Hardware Missing"),
+      "../assets/offroad/icon_monitoring.png",
+    },
+    {
       "IsMetric",
       tr("Use Metric System"),
       tr("Display speed in km/h instead of mph."),

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -518,7 +518,10 @@ void AnnotatedCameraWidget::drawDriverState(QPainter &painter, const UIState *s)
   offset += statusBarHeight / 2;
   int y = height() - offset;
   float opacity = dmActive ? 0.65 : 0.2;
-  drawIcon(painter, QPoint(x, y), dm_img, blackColor(70), opacity);
+  bool dm_missing = params.getBool("DriverCameraHardwareMissing");
+  if (!dm_missing) {
+    drawIcon(painter, QPoint(x, y), dm_img, blackColor(70), opacity);
+  }
 
   // face
   QPointF face_kpts_draw[std::size(default_face_kpts_3d)];

--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -101,6 +101,7 @@ private:
 
   // FrogPilot variables
   Params paramsMemory{"/dev/shm/params"};
+  Params params;
 
   Compass *compass_img;
   DistanceButton *distance_btn;

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -165,6 +165,8 @@ def manager_thread() -> None:
   if os.getenv("NOBOARD") is not None:
     ignore.append("pandad")
   ignore += [x for x in os.getenv("BLOCK", "").split(",") if len(x) > 0]
+  if params.get_bool("DriverCameraHardwareMissing"):
+    ignore += ["dmonitoringd", "dmonitoringmodeld"]
 
   sm = messaging.SubMaster(['deviceState', 'carParams', 'frogpilotPlan'], poll='deviceState')
   pm = messaging.PubMaster(['managerState'])


### PR DESCRIPTION
## Summary
- add persistent DriverCameraHardwareMissing param
- allow ignoring driver monitoring when hardware absent
- add toggle for missing driver camera
- hide driver camera icon when hardware missing
- skip driver monitoring processes when hardware missing

## Testing
- `pytest -q` *(fails: pyenv 3.11.4 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68643938f97c832888f742575aa4a72e