### PR TITLE
Rename FrogPilot to FSDPilot in UI

### DIFF
--- a/selfdrive/frogpilot/fleetmanager/templates/layout.html
+++ b/selfdrive/frogpilot/fleetmanager/templates/layout.html
@@ -40,13 +40,13 @@
     text-align: center;
   }
 </style>
-  <title>FrogPilot: {% block title %}{% endblock %}</title>
+  <title>FSDPilot: {% block title %}{% endblock %}</title>
 </head>
 <body>
   <nav class="navbar navbar-fixed-top navbar-expand-sm navbar-dark bg-dark">
     <div class="container">
       <a href="/" class="navbar-brand mb-0 h1">
-        <img class="d-inline-block align-top mr-2" src="/static/frog.png" /> FrogPilot </a>
+        <img class="d-inline-block align-top mr-2" src="/static/frog.png" /> FSDPilot </a>
       <button type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" class="navbar-toggler" aria-controls="navbarNav" aria-expanded="false" arial-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/selfdrive/frogpilot/ui/qt/offroad/data_settings.cc
+++ b/selfdrive/frogpilot/ui/qt/offroad/data_settings.cc
@@ -153,7 +153,7 @@ FrogPilotDataPanel::FrogPilotDataPanel(FrogPilotSettingsWindow *parent) : FrogPi
     } else if (id == 2) {
       QString selection = MultiOptionDialog::getSelection(tr("Select a restore point"), backupNames, "", this);
       if (!selection.isEmpty()) {
-        if (ConfirmationDialog::confirm(tr("Are you sure you want to restore this version of FrogPilot?"), tr("Restore"), this)) {
+        if (ConfirmationDialog::confirm(tr("Are you sure you want to restore this version of FSDPilot?"), tr("Restore"), this)) {
           std::thread([=]() {
             device()->resetInteractiveTimeout(300);
 

--- a/selfdrive/frogpilot/ui/qt/offroad/frogpilot_settings.cc
+++ b/selfdrive/frogpilot/ui/qt/offroad/frogpilot_settings.cc
@@ -103,11 +103,11 @@ FrogPilotSettingsWindow::FrogPilotSettingsWindow(SettingsWindow *parent) : QFram
   };
 
   std::vector<QString> descriptions = {
-    tr("Options to customize FrogPilot's sound alerts and notifications."),
-    tr("FrogPilot features that impact acceleration, braking, and steering."),
+    tr("Options to customize FSDPilot's sound alerts and notifications."),
+    tr("FSDPilot features that impact acceleration, braking, and steering."),
     tr("Offline maps downloader and 'Navigate On openpilot (NOO)' settings."),
-    tr("Tools and system utilities used to maintain and troubleshoot FrogPilot."),
-    tr("Options for customizing FrogPilot's themes, UI appearance, and onroad widgets."),
+    tr("Tools and system utilities used to maintain and troubleshoot FSDPilot."),
+    tr("Options for customizing FSDPilot's themes, UI appearance, and onroad widgets."),
     tr("Vehicle-specific settings and configurations for supported makes and models.")
   };
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -459,7 +459,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
     {tr("Network"), new Networking(this)},
     {tr("Toggles"), toggles},
     {tr("Software"), new SoftwarePanel(this)},
-    {tr("FrogPilot"), frogpilotSettingsWindow},
+    {tr("FSDPilot"), frogpilotSettingsWindow},
   };
 
   nav_btns = new QButtonGroup(this);

--- a/selfdrive/ui/qt/offroad/software_settings.cc
+++ b/selfdrive/ui/qt/offroad/software_settings.cc
@@ -30,8 +30,8 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
   addItem(versionLbl);
 
   // automatic updates toggle
-  ParamControl *automaticUpdatesToggle = new ParamControl("AutomaticUpdates", tr("Automatically Update FrogPilot"),
-                                                       tr("FrogPilot will automatically update itself and it's assets when you're offroad and connected to Wi-Fi."), "");
+  ParamControl *automaticUpdatesToggle = new ParamControl("AutomaticUpdates", tr("Automatically Update FSDPilot"),
+                                                       tr("FSDPilot will automatically update itself and it's assets when you're offroad and connected to Wi-Fi."), "");
   connect(automaticUpdatesToggle, &ToggleControl::toggleFlipped, this, updateFrogPilotToggles);
   addItem(automaticUpdatesToggle);
 
@@ -91,7 +91,7 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
   auto uninstallBtn = new ButtonControl(tr("Uninstall %1").arg(getBrand()), tr("UNINSTALL"));
   connect(uninstallBtn, &ButtonControl::clicked, [&]() {
     if (ConfirmationDialog::confirm(tr("Are you sure you want to uninstall?"), tr("Uninstall"), this)) {
-      if (FrogPilotConfirmationDialog::yesorno(tr("Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls."), this, true)) {
+      if (FrogPilotConfirmationDialog::yesorno(tr("Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls."), this, true)) {
         std::system("rm -rf /data/backups");
         std::system("rm -rf /data/crashes");
         std::system("rm -rf /data/media/screen_recordings");

--- a/selfdrive/ui/qt/util.cc
+++ b/selfdrive/ui/qt/util.cc
@@ -26,7 +26,7 @@ QString getVersion() {
 }
 
 QString getBrand() {
-  return QObject::tr("FrogPilot");
+  return QObject::tr("FSDPilot");
 }
 
 QString getUserAgent() {

--- a/selfdrive/ui/translations/main_ar.ts
+++ b/selfdrive/ui/translations/main_ar.ts
@@ -685,11 +685,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation>النسخ الاحتياطية لـ FSDPilot</translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation>إدارة النسخ الاحتياطية لـ FSDPilot.</translation>
     </message>
     <message>
@@ -733,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation>هل أنت متأكد أنك تريد استعادة هذا الإصدار من FSDPilot؟</translation>
     </message>
     <message>
@@ -2305,27 +2305,27 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation>ضوابط المركبات</translation>
     </message>
     <message>
-        <source>Advanced FrogPilot features for more experienced users.</source>
+        <source>Advanced FSDPilot features for more experienced users.</source>
         <translation type="vanished">ميزات FSDPilot المتقدمة للمستخدمين الأكثر خبرة.</translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation>خيارات لتخصيص تنبيهات وإشعارات الصوت لـ FSDPilot.</translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
-        <translation>ميزات FrogPilot التي تؤثر على التسارع والفرملة والتوجيه.</translation>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
+        <translation>ميزات FSDPilot التي تؤثر على التسارع والفرملة والتوجيه.</translation>
     </message>
     <message>
         <source>Offline maps downloader and &apos;Navigate On openpilot (NOO)&apos; settings.</source>
         <translation>تنزيل خرائط غير متصل و &quot;تنقل على OpenPilot (NOO)&quot;.</translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation>أدوات ونوافذ نظام تُستخدم لصيانة واستكشاف أخطاء FSDPilot.</translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation>خيارات لتخصيص سمات FSDPilot ومظهر الواجهة وعناصر القيادة.</translation>
     </message>
     <message>
@@ -2522,7 +2522,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation>الماعز صراخ توجيه تنبيه مشبع</translation>
     </message>
     <message>
-        <source>Enable the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enable the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="vanished">تمكين الصرخة الشهيرة &quot;صراخ الماعز&quot; التي جلبت الفرح والغضب لمستخدمي FSDPilot حول العالم!</translation>
     </message>
     <message>
@@ -2562,7 +2562,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2607,7 +2607,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Themed color schemes.
 
-Want to submit your own color scheme? Share it in the &apos;feature-request&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;feature-request&apos; channel on the FSDPilot Discord!</source>
         <translation type="vanished">مخططات ألوان مخصصة.
 هل تريد تقديم مخطط الألوان الخاص بك؟ شاركه في قناة &quot;feature-request&quot; على خادم FSDPilot في ديسكورد!</translation>
     </message>
@@ -2618,7 +2618,7 @@ Want to submit your own color scheme? Share it in the &apos;feature-request&apos
     <message>
         <source>Themed icon packs.
 
-Want to submit your own icons? Share them in the &apos;feature-request&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;feature-request&apos; channel on the FSDPilot Discord!</source>
         <translation type="vanished">حزم أيقونات مخصصة.
 هل تريد تقديم أيقوناتك الخاصة؟ شاركها في قناة &quot;feature-request&quot; على خادم FSDPilot في ديسكورد!</translation>
     </message>
@@ -2629,7 +2629,7 @@ Want to submit your own icons? Share them in the &apos;feature-request&apos; cha
     <message>
         <source>Themed sound effects.
 
-Want to submit your own sounds? Share them in the &apos;feature-request&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;feature-request&apos; channel on the FSDPilot Discord!</source>
         <translation type="vanished">مؤثرات صوتية مخصصة.
 هل تريد تقديم أصواتك الخاصة؟ شاركها في قناة &quot;feature-request&quot; على خادم FSDPilot في ديسكورد!</translation>
     </message>
@@ -2648,7 +2648,7 @@ Want to submit your own sounds? Share them in the &apos;feature-request&apos; ch
     <message>
         <source>Themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;feature-request&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;feature-request&apos; channel on the FSDPilot Discord!</source>
         <translation type="vanished">رسوم متحركة لإشارات الانعطاف مخصصة.
 هل تريد تقديم رسوماتك المتحركة الخاصة؟ شاركها في قناة &quot;feature-request&quot; على خادم FSDPilot في ديسكورد!</translation>
     </message>
@@ -2811,19 +2811,19 @@ Want to submit your own animations? Share them in the &apos;feature-request&apos
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3059,7 +3059,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation>عناصر FSDPilot المخصصة المستخدمة في واجهة القيادة.</translation>
     </message>
     <message>
@@ -3938,7 +3938,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation>الآن</translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation>FSDPilot</translation>
     </message>
 </context>
@@ -4010,11 +4010,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation>FSDPilot</translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4022,7 +4022,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4030,11 +4030,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4334,15 +4334,15 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation>تحديث FSDPilot تلقائياً</translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation>سيقوم FSDPilot بتحديث نفسه وموارده تلقائياً عند التوقف عن القيادة والاتصال بشبكة واي فاي.</translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, downloaded models, themes, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, downloaded models, themes, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="vanished">هل تريد حذف أي ملفات إضافية لـ FSDPilot بشكل نهائي؟ هذا غير قابل للاسترجاع تماماً ويتضمن النسخ الاحتياطية والنماذج المحملة والسمات وإعدادات التخزين طويلة المدى لتسهيل إعادة التثبيت.</translation>
     </message>
     <message>
@@ -4358,7 +4358,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -674,11 +674,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -722,7 +722,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2290,11 +2290,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2302,11 +2302,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2497,7 +2497,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2694,19 +2694,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2716,7 +2716,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2902,7 +2902,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3764,7 +3764,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3835,11 +3835,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3847,7 +3847,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3855,11 +3855,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4161,11 +4161,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4181,7 +4181,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -685,11 +685,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2301,11 +2301,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2313,11 +2313,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2508,7 +2508,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2705,19 +2705,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2727,7 +2727,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2913,7 +2913,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3776,7 +3776,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3848,11 +3848,11 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3860,7 +3860,7 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3868,11 +3868,11 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4172,11 +4172,11 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4192,7 +4192,7 @@ Cela peut prendre jusqu&apos;à une minute.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -674,11 +674,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -722,7 +722,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2290,11 +2290,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2302,11 +2302,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2497,7 +2497,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2694,19 +2694,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2716,7 +2716,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2902,7 +2902,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3760,7 +3760,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3831,11 +3831,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3843,7 +3843,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3851,11 +3851,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4155,11 +4155,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4175,7 +4175,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -685,11 +685,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2301,11 +2301,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2313,11 +2313,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2508,7 +2508,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2705,19 +2705,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2727,7 +2727,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2913,7 +2913,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3772,7 +3772,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation>now</translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3844,11 +3844,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3856,7 +3856,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3864,11 +3864,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4168,11 +4168,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4188,7 +4188,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -685,11 +685,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2301,11 +2301,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2313,11 +2313,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2508,7 +2508,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2705,19 +2705,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2727,7 +2727,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2913,7 +2913,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3776,7 +3776,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation>agora</translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3848,11 +3848,11 @@ Isso pode levar até um minuto.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3860,7 +3860,7 @@ Isso pode levar até um minuto.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3868,11 +3868,11 @@ Isso pode levar até um minuto.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4172,11 +4172,11 @@ Isso pode levar até um minuto.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4192,7 +4192,7 @@ Isso pode levar até um minuto.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_th.ts
+++ b/selfdrive/ui/translations/main_th.ts
@@ -685,11 +685,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2301,11 +2301,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2313,11 +2313,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2508,7 +2508,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2705,19 +2705,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2727,7 +2727,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2913,7 +2913,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3772,7 +3772,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation>ตอนนี้</translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3844,11 +3844,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3856,7 +3856,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3864,11 +3864,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4168,11 +4168,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4188,7 +4188,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_tr.ts
+++ b/selfdrive/ui/translations/main_tr.ts
@@ -666,11 +666,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -714,7 +714,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2282,11 +2282,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2294,11 +2294,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2489,7 +2489,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2686,19 +2686,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2708,7 +2708,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2894,7 +2894,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3752,7 +3752,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3823,11 +3823,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3835,7 +3835,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3843,11 +3843,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4143,11 +4143,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4163,7 +4163,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -685,11 +685,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2301,11 +2301,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2313,11 +2313,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2508,7 +2508,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2705,19 +2705,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2727,7 +2727,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2913,7 +2913,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3772,7 +3772,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation>现在</translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3844,11 +3844,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3856,7 +3856,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3864,11 +3864,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4168,11 +4168,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4188,7 +4188,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -685,11 +685,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot Backups</source>
+        <source>FSDPilot Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Manage your FrogPilot backups.</source>
+        <source>Manage your FSDPilot backups.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,7 +733,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to restore this version of FrogPilot?</source>
+        <source>Are you sure you want to restore this version of FSDPilot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2301,11 +2301,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options to customize FrogPilot&apos;s sound alerts and notifications.</source>
+        <source>Options to customize FSDPilot&apos;s sound alerts and notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot features that impact acceleration, braking, and steering.</source>
+        <source>FSDPilot features that impact acceleration, braking, and steering.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2313,11 +2313,11 @@ This overrides &apos;Conditional Experimental Mode&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tools and system utilities used to maintain and troubleshoot FrogPilot.</source>
+        <source>Tools and system utilities used to maintain and troubleshoot FSDPilot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Options for customizing FrogPilot&apos;s themes, UI appearance, and onroad widgets.</source>
+        <source>Options for customizing FSDPilot&apos;s themes, UI appearance, and onroad widgets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2508,7 +2508,7 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FrogPilot users all around the world!</source>
+        <source>Enables the famed &apos;Goat Scream&apos; that has brought both joy and anger to FSDPilot users all around the world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2705,19 +2705,19 @@ DISENGAGE IMMEDIATELY, Driver Unresponsive</source>
     <message>
         <source>Changes out openpilot&apos;s color scheme.
 
-Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own color scheme? Share it in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s icon pack.
 
-Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own icons? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changes out openpilot&apos;s sound effects.
 
-Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own sounds? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2727,7 +2727,7 @@ Want to submit your own sounds? Share them in the &apos;custom-themes&apos; chan
     <message>
         <source>Enables themed turn signal animations.
 
-Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FrogPilot Discord!</source>
+Want to submit your own animations? Share them in the &apos;custom-themes&apos; channel on the FSDPilot Discord!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2913,7 +2913,7 @@ Want to submit your own animations? Share them in the &apos;custom-themes&apos; 
 <context>
     <name>FrogPilotVisualsPanel</name>
     <message>
-        <source>Custom FrogPilot widgets used in the onroad user interface.</source>
+        <source>Custom FSDPilot widgets used in the onroad user interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3772,7 +3772,7 @@ Default matches half of the MUTCD standard of 4 inches.</source>
         <translation>現在</translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3844,11 +3844,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot</source>
+        <source>FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to FrogPilot! Since you&apos;re new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Welcome to FSDPilot! Since you&apos;re new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3856,7 +3856,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re fairly new to FrogPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re fairly new to FSDPilot, the &apos;Basic&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3864,11 +3864,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re experienced with FrogPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re experienced with FSDPilot, the &apos;Standard&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Since you&apos;re very experienced with FrogPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
+        <source>Since you&apos;re very experienced with FSDPilot, the &apos;Advanced&apos; toggle preset has been applied, but you can change this at any time via the &apos;Customization Level&apos; button!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4168,11 +4168,11 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically Update FrogPilot</source>
+        <source>Automatically Update FSDPilot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FrogPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
+        <source>FSDPilot will automatically update itself and it&apos;s assets when you&apos;re offroad and connected to Wi-Fi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4188,7 +4188,7 @@ This may take up to a minute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to permanently delete any additional FrogPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
+        <source>Do you want to permanently delete any additional FSDPilot assets? This is 100% unrecoverable and includes backups, models, and long-term storage toggle settings for easy reinstalls.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
## Summary
- rename brand strings from FrogPilot to FSDPilot in the UI

## Testing
- `grep -R "FSDPilot" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_6867ef0990fc8328ab82683bfcd0a3a2