### PR TITLE
Add Live Status Icon toggle

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -569,6 +569,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"WD40LiveTorqueParameters", PERSISTENT},
     {"WD40Score", PERSISTENT | FROGPILOT_CONTROLS},
     {"WheelIcon", PERSISTENT | FROGPILOT_STORAGE | FROGPILOT_VISUALS},
+    {"LiveStatusIcon", PERSISTENT | FROGPILOT_STORAGE | FROGPILOT_VISUALS},
     {"WheelSpeed", PERSISTENT | FROGPILOT_STORAGE | FROGPILOT_VISUALS},
     {"WheelToDownload", PERSISTENT},
 };

--- a/selfdrive/frogpilot/frogpilot_variables.py
+++ b/selfdrive/frogpilot/frogpilot_variables.py
@@ -266,6 +266,7 @@ frogpilot_default_params: list[tuple[str, str | bytes]] = [
   ("RoadEdgesWidth", "2"),
   ("RoadNameUI", "1"),
   ("RotatingWheel", "1"),
+  ("LiveStatusIcon", "1"),
   ("ScreenBrightness", "101"),
   ("ScreenBrightnessOnroad", "101"),
   ("ScreenManagement", "1"),
@@ -519,6 +520,7 @@ class FrogPilotVariables:
     toggle.dynamic_pedals_on_ui = toggle.pedals_on_ui and self.params.get_bool("DynamicPedalsOnUI")
     toggle.static_pedals_on_ui = toggle.pedals_on_ui and self.params.get_bool("StaticPedalsOnUI")
     toggle.rotating_wheel = toggle.custom_ui and self.params.get_bool("RotatingWheel")
+    toggle.live_status_icon = toggle.custom_ui and self.params.get_bool("LiveStatusIcon")
 
     toggle.developer_ui = self.params.get_bool("DeveloperUI")
     toggle.border_metrics = toggle.developer_ui and self.params.get_bool("BorderMetrics")
@@ -824,6 +826,7 @@ class FrogPilotVariables:
       toggle.dynamic_pedals_on_ui = toggle.pedals_on_ui and self.default_frogpilot_toggles.DynamicPedalsOnUI
       toggle.static_pedals_on_ui = toggle.pedals_on_ui and self.default_frogpilot_toggles.StaticPedalsOnUI
       toggle.rotating_wheel = toggle.custom_ui and self.default_frogpilot_toggles.RotatingWheel
+      toggle.live_status_icon = toggle.custom_ui and self.default_frogpilot_toggles.LiveStatusIcon
 
       toggle.developer_ui = self.default_frogpilot_toggles.DeveloperUI
       toggle.border_metrics = toggle.developer_ui and self.default_frogpilot_toggles.BorderMetrics

--- a/selfdrive/frogpilot/ui/qt/offroad/visual_settings.cc
+++ b/selfdrive/frogpilot/ui/qt/offroad/visual_settings.cc
@@ -48,7 +48,8 @@ FrogPilotVisualsPanel::FrogPilotVisualsPanel(FrogPilotSettingsWindow *parent) : 
     {"BlindSpotPath", tr("Blind Spot Path"), tr("Projects a red path when vehicles are detected in the blind spot for the respective lane."), ""},
     {"Compass", tr("Compass"), tr("Displays a compass to show the current driving direction."), ""},
     {"PedalsOnUI", tr("Gas / Brake Pedal Indicators"), tr("Displays pedal indicators to indicate when either of the pedals are currently being used."), ""},
-    {"RotatingWheel", tr("Rotating Steering Wheel"), tr("Rotates the steering wheel in the onroad UI rotates along with your steering wheel movements."), ""}
+    {"RotatingWheel", tr("Rotating Steering Wheel"), tr("Rotates the steering wheel in the onroad UI rotates along with your steering wheel movements."), ""},
+    {"LiveStatusIcon", tr("Live Status Icon"), tr("Displays a color-coded icon indicating the current system status near the speed display."), ""}
   };
 
   for (const auto &[param, title, desc, icon] : visualToggles) {

--- a/selfdrive/frogpilot/ui/qt/offroad/visual_settings.h
+++ b/selfdrive/frogpilot/ui/qt/offroad/visual_settings.h
@@ -32,7 +32,7 @@ private:
 
   std::set<QString> customOnroadUIKeys = {
     "AccelerationPath", "AdjacentPath", "BlindSpotPath",
-    "Compass", "PedalsOnUI", "RotatingWheel"
+    "Compass", "PedalsOnUI", "RotatingWheel", "LiveStatusIcon"
   };
 
   std::set<QString> developerUIKeys = {

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -936,6 +936,7 @@ void AnnotatedCameraWidget::updateFrogPilotVariables(int alert_height, const UIS
   }
 
   roadNameUI = scene.road_name_ui;
+  showLiveIcon = scene.show_live_status_icon;
 
   bool enableScreenRecorder = scene.screen_recorder && !mapOpen;
   screenRecorder->setVisible(enableScreenRecorder);
@@ -985,6 +986,10 @@ void AnnotatedCameraWidget::paintFrogPilotWidgets(QPainter &painter) {
 
   if (speedLimitChanged) {
     drawSLCConfirmation(painter);
+  }
+
+  if (showLiveIcon) {
+    drawLiveStatusIcon(painter);
   }
 
   if (turnSignalAnimation && (turnSignalLeft || turnSignalRight) && !bigMapOpen && ((!mapOpen && standstillDuration == 0) || signalStyle != "static")) {
@@ -1352,6 +1357,18 @@ void AnnotatedCameraWidget::drawStatusBar(QPainter &p) {
     p.drawText(textRect, Qt::AlignCenter | Qt::TextWordWrap, roadName);
   }
 
+  p.restore();
+}
+
+void AnnotatedCameraWidget::drawLiveStatusIcon(QPainter &p) {
+  int radius = 20;
+  int x = width() - radius - 30;
+  int y = 60;
+  QColor color = bg_colors[status];
+  p.save();
+  p.setBrush(color);
+  p.setPen(Qt::NoPen);
+  p.drawEllipse(QPoint(x, y), radius, radius);
   p.restore();
 }
 

--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -93,6 +93,7 @@ private:
   void drawLeadInfo(QPainter &p);
   void drawSLCConfirmation(QPainter &p);
   void drawStatusBar(QPainter &p);
+  void drawLiveStatusIcon(QPainter &p);
   void drawTurnSignals(QPainter &p);
   void initializeFrogPilotWidgets();
   void paintFrogPilotWidgets(QPainter &painter);
@@ -122,6 +123,7 @@ private:
   bool mapOpen;
   bool onroadDistanceButton;
   bool roadNameUI;
+  bool showLiveIcon;
   bool showAlwaysOnLateralStatusBar;
   bool showConditionalExperimentalStatusBar;
   bool showSLCOffset;

--- a/selfdrive/ui/qt/onroad/onroad_home.cc
+++ b/selfdrive/ui/qt/onroad/onroad_home.cc
@@ -95,6 +95,7 @@ void OnroadWindow::updateState(const UIState &s) {
   liveValid = scene.live_valid;
   showBlindspot = scene.show_blind_spot && (blindSpotLeft || blindSpotRight);
   showFPS = scene.show_fps;
+  showLiveIcon = scene.show_live_status_icon;
   showJerk = scene.jerk_metrics;
   showSignal = scene.signal_metrics && (turnSignalLeft || turnSignalRight);
   showSteering = scene.steering_metrics;
@@ -106,7 +107,7 @@ void OnroadWindow::updateState(const UIState &s) {
   turnSignalLeft = scene.turn_signal_left;
   turnSignalRight = scene.turn_signal_right;
 
-  if (showBlindspot || showFPS || (showJerk && hasLead) || showSignal || showSteering || showTuning) {
+  if (showBlindspot || showFPS || showLiveIcon || (showJerk && hasLead) || showSignal || showSteering || showTuning) {
     shouldUpdate = true;
   }
 

--- a/selfdrive/ui/qt/onroad/onroad_home.h
+++ b/selfdrive/ui/qt/onroad/onroad_home.h
@@ -31,6 +31,7 @@ private:
   bool liveValid;
   bool showBlindspot;
   bool showFPS;
+  bool showLiveIcon;
   bool showJerk;
   bool showSignal;
   bool showSteering;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -406,6 +406,7 @@ void ui_update_frogpilot_params(UIState *s) {
   scene.screen_timeout_onroad = scene.frogpilot_toggles.value("screen_timeout_onroad").toDouble();
   scene.show_blind_spot = static_cast<bool>(scene.frogpilot_toggles.value("blind_spot_metrics").toBool());
   scene.show_fps = static_cast<bool>(scene.frogpilot_toggles.value("show_fps").toBool());
+  scene.show_live_status_icon = static_cast<bool>(scene.frogpilot_toggles.value("live_status_icon").toBool());
   scene.show_speed_limit_offset = static_cast<bool>(scene.frogpilot_toggles.value("show_speed_limit_offset").toBool());
   scene.show_stopping_point = static_cast<bool>(scene.frogpilot_toggles.value("show_stopping_point").toBool());
   scene.show_stopping_point_metrics = static_cast<bool>(scene.frogpilot_toggles.value("show_stopping_point_metrics").toBool());

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -191,6 +191,7 @@ typedef struct UIScene {
   bool screen_recorder;
   bool show_blind_spot;
   bool show_fps;
+  bool show_live_status_icon;
   bool show_speed_limit_offset;
   bool show_stopping_point;
   bool show_stopping_point_metrics;


### PR DESCRIPTION

- add LiveStatusIcon parameter
- expose toggle in FrogPilot visual settings
- track show_live_status_icon in UI state
- draw a colored system status icon onroad
