### PR TITLE
Add VoiceAssistantEnabled param

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -207,6 +207,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"UpdaterTargetBranch", CLEAR_ON_MANAGER_START},
     {"UpdaterLastFetchTime", PERSISTENT},
     {"Version", PERSISTENT},
+    {"VoiceAssistantEnabled", PERSISTENT},
 
     // FrogPilot parameters
     {"AccelerationPath", PERSISTENT | FROGPILOT_STORAGE | FROGPILOT_VISUALS},

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -70,7 +70,8 @@ def manager_init() -> None:
     ("RecordFront", "0"),
     ("SshEnabled", "0"),
     ("TetheringEnabled", "0"),
-    ("LongitudinalPersonality", str(log.LongitudinalPersonality.standard))
+    ("LongitudinalPersonality", str(log.LongitudinalPersonality.standard)),
+    ("VoiceAssistantEnabled", "0")
   ]
   if not PC:
     default_params.append(("LastUpdateTime", datetime.datetime.utcnow().isoformat().encode('utf8')))


### PR DESCRIPTION
## Summary
- add new persistent parameter `VoiceAssistantEnabled`
- include `VoiceAssistantEnabled` with a default of off in manager default params

## Testing
- `pre-commit run --files common/params.cc system/manager/manager.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870920599fc8328accb6bc1531e744b