### PR TITLE
Implement AALC warning and UI tweaks

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -32,7 +32,7 @@ from openpilot.selfdrive.controls.lib.vehicle_model import VehicleModel
 from openpilot.system.hardware import HARDWARE
 
 from openpilot.selfdrive.frogpilot.controls.lib.frogpilot_acceleration import get_max_allowed_accel
-from openpilot.selfdrive.frogpilot.frogpilot_variables import CRUISING_SPEED, NON_DRIVING_GEARS, get_frogpilot_toggles
+from openpilot.selfdrive.frogpilot.frogpilot_variables import NON_DRIVING_GEARS, get_frogpilot_toggles
 
 SOFT_DISABLE_TIME = 3  # seconds
 LDW_MIN_SPEED = 31 * CV.MPH_TO_MS
@@ -577,10 +577,21 @@ class Controls:
     if self.CP.lateralTuning.which() == 'torque':
       torque_params = self.sm['liveTorqueParameters']
       friction = self.frogpilot_toggles.steer_friction if self.frogpilot_toggles.use_custom_steer_friction else torque_params.frictionCoefficientFiltered
-      lat_accel_factor = self.frogpilot_toggles.steer_lat_accel_factor if self.frogpilot_toggles.use_custom_lat_accel_factor else torque_params.latAccelFactorFiltered
-      if self.sm.all_checks(['liveTorqueParameters']) and (torque_params.useParams or self.frogpilot_toggles.force_auto_tune) and not self.frogpilot_toggles.force_auto_tune_off:
-        self.LaC.update_live_torque_params(lat_accel_factor, torque_params.latAccelOffsetFiltered,
-                                           friction)
+      lat_accel_factor = (
+        self.frogpilot_toggles.steer_lat_accel_factor
+        if self.frogpilot_toggles.use_custom_lat_accel_factor
+        else torque_params.latAccelFactorFiltered
+      )
+      if (
+        self.sm.all_checks(['liveTorqueParameters'])
+        and (torque_params.useParams or self.frogpilot_toggles.force_auto_tune)
+        and not self.frogpilot_toggles.force_auto_tune_off
+      ):
+        self.LaC.update_live_torque_params(
+          lat_accel_factor,
+          torque_params.latAccelOffsetFiltered,
+          friction,
+        )
 
     long_plan = self.sm['longitudinalPlan']
     model_v2 = self.sm['modelV2']
@@ -597,10 +608,13 @@ class Controls:
     actuators = CC.actuators
     actuators.longControlState = self.LoC.long_control_state
 
-    # Enable blinkers while lane changing
+    # Enable blinkers while lane changing or during AALC countdown
     if model_v2.meta.laneChangeState != LaneChangeState.off:
       CC.leftBlinker = model_v2.meta.laneChangeDirection == LaneChangeDirection.left
       CC.rightBlinker = model_v2.meta.laneChangeDirection == LaneChangeDirection.right
+    elif self.sm['frogpilotPlan'].aalcActive:
+      CC.leftBlinker = True
+      CC.rightBlinker = False
 
     if CS.leftBlinker or CS.rightBlinker:
       self.last_blinker_frame = self.sm.frame
@@ -625,7 +639,13 @@ class Controls:
         t_since_plan = (self.sm.frame - self.sm.recv_frame['longitudinalPlan']) * DT_CTRL
         actuators.accel = self.LoC.update_old_long(CC.longActive, CS, long_plan, pid_accel_limits, t_since_plan)
       else:
-        actuators.accel = self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop or self.sm['frogpilotPlan'].forcingStopLength <= 0, pid_accel_limits)
+        actuators.accel = self.LoC.update(
+          CC.longActive,
+          CS,
+          long_plan.aTarget,
+          long_plan.shouldStop or self.sm['frogpilotPlan'].forcingStopLength <= 0,
+          pid_accel_limits,
+        )
 
       if len(long_plan.speeds):
         actuators.speed = long_plan.speeds[-1]

--- a/selfdrive/controls/lib/desire_helper.py
+++ b/selfdrive/controls/lib/desire_helper.py
@@ -55,6 +55,7 @@ class DesireHelper:
     self.turn_direction = TurnDirection.none
     self.aalc_active = False
     self.aalc_timer = 0.0
+    self.aalc_delay_timer = 0.0
 
   def update(self, carstate, lateral_active, lane_change_prob, frogpilotPlan, frogpilot_toggles):
     v_ego = carstate.vEgo
@@ -78,9 +79,17 @@ class DesireHelper:
     aalc_trigger = (frogpilot_toggles.aalc_enabled and frogpilotPlan.aalcActive and lane_available
                     and lead_distance < 30 and blindspot_clear and speed_ok and no_manual and lanes_valid)
     if aalc_trigger and self.lane_change_state == LaneChangeState.off:
-      self.lane_change_state = LaneChangeState.laneChangeStarting
-      self.lane_change_direction = LaneChangeDirection.left
-      self.aalc_active = True
+      if self.aalc_delay_timer == 0.0:
+        self.aalc_delay_timer = 10.0
+        self.aalc_active = True
+      else:
+        self.aalc_delay_timer = max(0.0, self.aalc_delay_timer - DT_MDL)
+        if self.aalc_delay_timer == 0.0:
+          self.lane_change_state = LaneChangeState.laneChangeStarting
+          self.lane_change_direction = LaneChangeDirection.left
+    else:
+      self.aalc_delay_timer = 0.0
+      self.aalc_active = False
 
     if not lateral_active or self.lane_change_timer > LANE_CHANGE_TIME_MAX:
       self.lane_change_state = LaneChangeState.off

--- a/selfdrive/frogpilot/controls/frogpilot_planner.py
+++ b/selfdrive/frogpilot/controls/frogpilot_planner.py
@@ -52,7 +52,7 @@ class FrogPilotPlanner:
     v_cruise = min(controlsState.vCruise, V_CRUISE_UNSET) * CV.KPH_TO_MS
     v_ego = max(carState.vEgo, 0)
     v_lead = self.lead_one.vLead
-    self.slower_lead = self.lead_one.status and (v_ego - v_lead) >= 15 * CV.KPH_TO_MS
+    self.slower_lead = self.lead_one.status and (v_ego - v_lead) >= 20 * CV.KPH_TO_MS
 
     self.frogpilot_acceleration.update(controlsState, frogpilotCarState, v_cruise, v_ego, frogpilot_toggles)
 

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -39,6 +39,8 @@ AnnotatedCameraWidget::AnnotatedCameraWidget(VisionStreamType type, QWidget* par
   map_settings_btn = new MapSettingsButton(this);
   main_layout->addWidget(map_settings_btn, 0, Qt::AlignBottom | Qt::AlignRight);
 
+  aalcCountdown = 0.0;
+
   dm_img = loadPixmap("../assets/img_driver_face.png", {img_size + 5, img_size + 5});
 
   // Initialize FrogPilot widgets
@@ -871,7 +873,16 @@ void AnnotatedCameraWidget::updateFrogPilotVariables(int alert_height, const UIS
   alertHeight = alert_height;
 
   alwaysOnLateralActive = scene.always_on_lateral_active;
+  if (scene.aalc_active && !aalcActive) {
+    aalcTimer.start();
+    aalcCountdown = 10.0;
+  } else if (!scene.aalc_active) {
+    aalcCountdown = 0.0;
+  }
   aalcActive = scene.aalc_active;
+  if (aalcActive && aalcCountdown > 0.0) {
+    aalcCountdown = fmax(0.0, 10.0 - (aalcTimer.elapsed() / 1000.0));
+  }
   showAlwaysOnLateralStatusBar = scene.aol_status_bar;
 
   blindSpotLeft = scene.blind_spot_left;
@@ -992,15 +1003,23 @@ void AnnotatedCameraWidget::paintFrogPilotWidgets(QPainter &painter) {
     painter.save();
     painter.setPen(Qt::white);
     painter.setFont(InterFont(40, QFont::Bold));
-    painter.drawText(QRect(0, 100, width(), 50), Qt::AlignHCenter, tr("AALC ACTIVE"));
+    QString msg = aalcCountdown > 0.0 ? tr("AALC in %1s").arg(QString::number(std::ceil(aalcCountdown))) : tr("AALC ACTIVE");
+    painter.drawText(QRect(width()/2, 100, width()/2 - 60, 50), Qt::AlignRight, msg);
     painter.restore();
   }
 
-  if (turnSignalAnimation && (turnSignalLeft || turnSignalRight) && !bigMapOpen && ((!mapOpen && standstillDuration == 0) || signalStyle != "static")) {
+  if (turnSignalAnimation && (turnSignalLeft || turnSignalRight || aalcActive) && !bigMapOpen && ((!mapOpen && standstillDuration == 0) || signalStyle != "static")) {
+    bool tempLeft = turnSignalLeft;
+    bool tempRight = turnSignalRight;
+    if (aalcActive && !turnSignalLeft && !turnSignalRight) {
+      turnSignalLeft = true;
+    }
     if (!animationTimer->isActive()) {
       animationTimer->start(signalAnimationLength);
     }
     drawTurnSignals(painter);
+    turnSignalLeft = tempLeft;
+    turnSignalRight = tempRight;
   } else if (animationTimer->isActive()) {
     animationTimer->stop();
   }

--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QVBoxLayout>
+#include <QElapsedTimer>
 #include <memory>
 
 #include "selfdrive/ui/qt/onroad/buttons.h"
@@ -133,6 +134,8 @@ private:
   bool turnSignalLeft;
   bool turnSignalRight;
   bool aalcActive;
+  double aalcCountdown;
+  QElapsedTimer aalcTimer;
   bool useStockColors;
   bool useSI;
   bool useViennaSLCSign;


### PR DESCRIPTION
## Summary
- enhance FrogPilot auto lane change logic with a 10 s delay
- trigger lane change only when speed delta exceeds 20 kph
- show countdown in UI and move AALC message to the right
- allow turn signal animation during AALC
- flash turn signal during the AALC countdown

## Testing
- `pre-commit` failed: pyenv version `3.11.4` not installed
- `cppcheck` failed: `syntaxError` processing Python file

------
https://chatgpt.com/codex/tasks/task_e_686b459b73f48328b1dd8e694ffa34a7